### PR TITLE
add publish workflow and trim README

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish plyrfm to PyPI
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # For PyPI's trusted publishing
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish -v dist/*

--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ client = PlyrClient(
 
 ## API reference
 
-### `PlyrClient` / `AsyncPlyrClient`
-
 | method | auth | description |
 |--------|------|-------------|
 | `list_tracks(limit=50)` | no | list all public tracks |
@@ -106,35 +104,6 @@ client = PlyrClient(
 | `download(track_id, output=None)` | yes | download track audio |
 | `delete(track_id)` | yes | delete a track |
 | `me()` | yes | get current user info |
-
-### types
-
-```python
-@dataclass
-class Track:
-    id: int
-    title: str
-    file_id: str
-    file_type: str
-    artist: str
-    artist_handle: str
-    play_count: int
-    like_count: int
-    album: Album | None
-    image_url: str | None
-    created_at: datetime | None
-
-@dataclass
-class Album:
-    id: int
-    title: str
-    slug: str
-
-@dataclass
-class UploadResult:
-    track_id: int
-    title: str
-```
 
 ## environment variables
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for trusted publishing to PyPI (triggers on release or manual dispatch)
- remove verbose type definitions from README - types are exported but showing full dataclass definitions was unnecessary

## Test plan
- [ ] set up trusted publishing on PyPI for `plyrfm`
- [ ] merge and create a release to test the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)