### PR TITLE
fix: rename CLI executable from plyr to plyrfm

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,19 @@ export PLYR_TOKEN="your_token_here"
 ### CLI
 
 ```bash
+# install
+uvx plyrfm --help
+# or: uv tool install plyrfm
+
 # public (no auth required)
-plyr list                        # list all tracks
+plyrfm list                        # list all tracks
 
 # authenticated (requires PLYR_TOKEN)
-plyr my-tracks                   # list your tracks
-plyr upload track.mp3 "My Song"  # upload
-plyr download 42 -o song.mp3     # download
-plyr delete 42 -y                # delete
-plyr me                          # check auth
+plyrfm my-tracks                   # list your tracks
+plyrfm upload track.mp3 "My Song"  # upload
+plyrfm download 42 -o song.mp3     # download
+plyrfm delete 42 -y                # delete
+plyrfm me                          # check auth
 ```
 
 ### sync client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [project.scripts]
-plyr = "plyrfm.cli:main"
+plyrfm = "plyrfm.cli:main"
 
 [dependency-groups]
 dev = [

--- a/src/plyrfm/cli.py
+++ b/src/plyrfm/cli.py
@@ -192,10 +192,10 @@ def cmd_me() -> None:
 # -----------------------------------------------------------------------------
 
 USAGE = """\
-[bold]plyr[/] - plyr.fm CLI
+[bold]plyrfm[/] - plyr.fm CLI
 
 [bold]usage:[/]
-    plyr <command> [options]
+    plyrfm <command> [options]
 
 [bold]public commands (no auth):[/]
     list [--limit N]              list all tracks
@@ -213,10 +213,10 @@ USAGE = """\
     2. export PLYR_TOKEN="your_token"
 
 [bold]examples:[/]
-    plyr list                                    # no auth needed
-    plyr my-tracks                               # requires auth
-    plyr upload track.mp3 "My Song"              # requires auth
-    plyr download 42 -o song.mp3                 # requires auth
+    plyrfm list                                  # no auth needed
+    plyrfm my-tracks                             # requires auth
+    plyrfm upload track.mp3 "My Song"            # requires auth
+    plyrfm download 42 -o song.mp3               # requires auth
 """
 
 


### PR DESCRIPTION
## Summary
- rename CLI executable from `plyr` to `plyrfm`
- `plyr` is already taken on PyPI, so this lets users run `uvx plyrfm` directly

## Test plan
- [ ] merge and release
- [ ] verify `uvx plyrfm --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)