### PR TITLE
feat: add update_track method and client parity tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ client = PlyrClient(
 |--------|------|-------------|
 | `list_tracks(limit=50)` | no | list all public tracks |
 | `get_track(track_id)` | no | get track by ID |
-| `my_tracks(limit=50)` | yes | list your tracks (with liked state) |
+| `my_tracks(limit=50)` | yes | list your tracks |
 | `upload(file, title, album=None)` | yes | upload a track |
+| `update_track(track_id, title=None, album=None, image=None)` | yes | update track metadata |
 | `download(track_id, output=None)` | yes | download track audio |
 | `delete(track_id)` | yes | delete a track |
 | `me()` | yes | get current user info |

--- a/src/plyrfm/client.py
+++ b/src/plyrfm/client.py
@@ -175,6 +175,43 @@ class PlyrClient(_BaseClient):
 
         return self._poll_upload(upload_id, title, timeout=timeout)
 
+    def update_track(
+        self,
+        track_id: int,
+        *,
+        title: str | None = None,
+        album: str | None = None,
+        image: Path | str | None = None,
+    ) -> Track:
+        """update track metadata. requires auth + ownership."""
+        data: dict[str, str] = {}
+        if title is not None:
+            data["title"] = title
+        if album is not None:
+            data["album"] = album
+
+        files = {}
+        if image is not None:
+            image = Path(image)
+            if not image.exists():
+                msg = f"image not found: {image}"
+                raise FileNotFoundError(msg)
+            files["image"] = (image.name, open(image, "rb"))
+
+        try:
+            response = self._client.patch(
+                self._url(f"/tracks/{track_id}"),
+                headers=self._auth_headers,
+                data=data if data else None,
+                files=files if files else None,
+            )
+        finally:
+            for _, f in files.values():
+                f.close()
+
+        self._handle_error_response(response)
+        return Track.from_dict(response.json())
+
     def _poll_upload(
         self,
         upload_id: str,
@@ -359,6 +396,43 @@ class AsyncPlyrClient(_BaseClient):
             raise ValueError(msg)
 
         return await self._poll_upload(upload_id, title, timeout=timeout)
+
+    async def update_track(
+        self,
+        track_id: int,
+        *,
+        title: str | None = None,
+        album: str | None = None,
+        image: Path | str | None = None,
+    ) -> Track:
+        """update track metadata. requires auth + ownership."""
+        data: dict[str, str] = {}
+        if title is not None:
+            data["title"] = title
+        if album is not None:
+            data["album"] = album
+
+        files = {}
+        if image is not None:
+            image = Path(image)
+            if not image.exists():
+                msg = f"image not found: {image}"
+                raise FileNotFoundError(msg)
+            files["image"] = (image.name, open(image, "rb"))
+
+        try:
+            response = await self._client.patch(
+                self._url(f"/tracks/{track_id}"),
+                headers=self._auth_headers,
+                data=data if data else None,
+                files=files if files else None,
+            )
+        finally:
+            for _, f in files.values():
+                f.close()
+
+        self._handle_error_response(response)
+        return Track.from_dict(response.json())
 
     async def _poll_upload(
         self,

--- a/tests/test_client_parity.py
+++ b/tests/test_client_parity.py
@@ -1,0 +1,59 @@
+"""test that PlyrClient and AsyncPlyrClient have the same public methods."""
+
+import inspect
+
+from plyrfm import AsyncPlyrClient, PlyrClient
+
+
+def get_public_methods(cls: type) -> set[str]:
+    """get public method names (excluding dunder and private)."""
+    return {
+        name
+        for name, _ in inspect.getmembers(cls, predicate=inspect.isfunction)
+        if not name.startswith("_")
+    }
+
+
+def test_clients_have_same_methods():
+    """sync and async clients should expose the same public API."""
+    sync_methods = get_public_methods(PlyrClient)
+    async_methods = get_public_methods(AsyncPlyrClient)
+
+    assert sync_methods == async_methods, (
+        f"method mismatch:\n"
+        f"  only in sync: {sync_methods - async_methods}\n"
+        f"  only in async: {async_methods - sync_methods}"
+    )
+
+
+def test_methods_have_same_signatures():
+    """sync and async methods should have the same parameter signatures."""
+    sync_methods = get_public_methods(PlyrClient)
+
+    for method_name in sync_methods:
+        sync_method = getattr(PlyrClient, method_name)
+        async_method = getattr(AsyncPlyrClient, method_name)
+
+        sync_sig = inspect.signature(sync_method)
+        async_sig = inspect.signature(async_method)
+
+        # compare parameter names and defaults (ignore self)
+        sync_params = list(sync_sig.parameters.items())[1:]  # skip self
+        async_params = list(async_sig.parameters.items())[1:]
+
+        assert len(sync_params) == len(async_params), (
+            f"{method_name}: different param count"
+        )
+
+        for (sync_name, sync_param), (async_name, async_param) in zip(
+            sync_params, async_params
+        ):
+            assert sync_name == async_name, (
+                f"{method_name}: param name mismatch {sync_name} vs {async_name}"
+            )
+            assert sync_param.default == async_param.default, (
+                f"{method_name}.{sync_name}: default mismatch"
+            )
+            assert sync_param.annotation == async_param.annotation, (
+                f"{method_name}.{sync_name}: annotation mismatch"
+            )


### PR DESCRIPTION
## Summary
- add `update_track(track_id, title=None, album=None, image=None)` to both sync and async clients
- add tests to ensure `PlyrClient` and `AsyncPlyrClient` have the same public methods and signatures

## Test plan
- [x] parity tests pass
- [ ] merge and release
- [ ] test `update_track` against staging/prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)