### PR TITLE
add user-agent header to API requests

### DIFF
--- a/packages/plyrfm-mcp/src/plyrfm_mcp/client.py
+++ b/packages/plyrfm-mcp/src/plyrfm_mcp/client.py
@@ -5,10 +5,20 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from importlib.metadata import version
 
 from plyrfm import AsyncPlyrClient
 
 logger = logging.getLogger(__name__)
+
+
+def _get_user_agent() -> str:
+    """get user-agent string identifying MCP server."""
+    try:
+        v = version("plyrfm-mcp")
+    except Exception:
+        v = "unknown"
+    return f"plyrfm-mcp/{v}"
 
 
 def _get_token_from_context() -> str | None:
@@ -59,13 +69,15 @@ async def get_plyr_client(require_auth: bool = False) -> AsyncIterator[AsyncPlyr
     """
     token = _get_token_from_context()
 
+    user_agent = _get_user_agent()
+
     if token:
         logger.debug("using per-request token from context")
-        async with AsyncPlyrClient(token=token) as client:
+        async with AsyncPlyrClient(token=token, user_agent=user_agent) as client:
             yield client
     else:
         logger.debug("no per-request token, using environment defaults")
-        client = AsyncPlyrClient()
+        client = AsyncPlyrClient(user_agent=user_agent)
 
         if require_auth and not client._token:
             msg = (

--- a/packages/plyrfm/src/plyrfm/client.py
+++ b/packages/plyrfm/src/plyrfm/client.py
@@ -3,12 +3,22 @@
 from __future__ import annotations
 
 import json
+from importlib.metadata import version
 from pathlib import Path
 
 import httpx
 
 from plyrfm._internal.config import Settings, get_settings
 from plyrfm._internal.types import Track, UploadResult
+
+
+def _get_user_agent(client_name: str = "plyrfm") -> str:
+    """get user-agent string for API requests."""
+    try:
+        v = version(client_name)
+    except Exception:
+        v = "unknown"
+    return f"{client_name}/{v}"
 
 
 class _BaseClient:
@@ -71,9 +81,11 @@ class PlyrClient(_BaseClient):
         api_url: str | None = None,
         settings: Settings | None = None,
         timeout: float = 30.0,
+        user_agent: str | None = None,
     ) -> None:
         super().__init__(token=token, api_url=api_url, settings=settings)
-        self._client = httpx.Client(timeout=timeout)
+        headers = {"User-Agent": user_agent or _get_user_agent()}
+        self._client = httpx.Client(timeout=timeout, headers=headers)
 
     def __enter__(self) -> PlyrClient:
         return self
@@ -294,9 +306,11 @@ class AsyncPlyrClient(_BaseClient):
         api_url: str | None = None,
         settings: Settings | None = None,
         timeout: float = 30.0,
+        user_agent: str | None = None,
     ) -> None:
         super().__init__(token=token, api_url=api_url, settings=settings)
-        self._client = httpx.AsyncClient(timeout=timeout)
+        headers = {"User-Agent": user_agent or _get_user_agent()}
+        self._client = httpx.AsyncClient(timeout=timeout, headers=headers)
 
     async def __aenter__(self) -> AsyncPlyrClient:
         return self

--- a/tests/test_mcp_header_auth.py
+++ b/tests/test_mcp_header_auth.py
@@ -1,6 +1,6 @@
 """tests for MCP server header-based authentication."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from plyrfm_mcp.client import get_plyr_client
 from plyrfm_mcp.middleware import PlyrAuthMiddleware
@@ -92,7 +92,9 @@ async def test_get_plyr_client_with_context_token():
             assert client is mock_client
 
         # verify AsyncPlyrClient was called with token from context
-        mock_client_cls.assert_called_once_with(token="test-token-from-context")
+        mock_client_cls.assert_called_once_with(
+            token="test-token-from-context", user_agent=ANY
+        )
 
 
 async def test_get_plyr_client_fallback_to_environment():
@@ -114,7 +116,7 @@ async def test_get_plyr_client_fallback_to_environment():
             assert client is mock_client
 
         # verify AsyncPlyrClient was called without explicit token (uses env)
-        mock_client_cls.assert_called_once_with()
+        mock_client_cls.assert_called_once_with(user_agent=ANY)
 
 
 async def test_get_plyr_client_fallback_when_no_token_in_context():
@@ -139,7 +141,7 @@ async def test_get_plyr_client_fallback_when_no_token_in_context():
             assert client is mock_client
 
         # verify AsyncPlyrClient was called without explicit token
-        mock_client_cls.assert_called_once_with()
+        mock_client_cls.assert_called_once_with(user_agent=ANY)
 
 
 async def test_get_plyr_client_require_auth_raises_when_no_token():


### PR DESCRIPTION
SDK sends `plyrfm/{version}`, MCP server sends `plyrfm-mcp/{version}`.

allows backend to distinguish traffic source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)