### PR TITLE
add audio_url field to Track model

### DIFF
--- a/packages/plyrfm/src/plyrfm/_internal/types.py
+++ b/packages/plyrfm/src/plyrfm/_internal/types.py
@@ -43,6 +43,7 @@ class Track:
     like_count: int = 0
     album: Album | None = None
     image_url: str | None = None
+    audio_url: str | None = None
     created_at: datetime | None = None
 
     @classmethod
@@ -74,6 +75,7 @@ class Track:
             like_count=data.get("like_count", 0),
             album=album,
             image_url=data.get("image_url"),
+            audio_url=data.get("r2_url"),
             created_at=created_at,
         )
 


### PR DESCRIPTION
maps `r2_url` from API response to `audio_url` on Track.

```python
track = client.get_track(75)
print(track.audio_url)
# https://pub-d4ed8a1e39d44dac85263d86ad5676fd.r2.dev/audio/eeedea76aed295d3.wav
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)