### PR TITLE
feat: add tag support to SDK and CLI

### DIFF
--- a/packages/plyrfm-mcp/src/plyrfm_mcp/server.py
+++ b/packages/plyrfm-mcp/src/plyrfm_mcp/server.py
@@ -44,10 +44,21 @@ plyrfm upload path/to/track.mp3 "Song Title"
 
 # upload with album
 plyrfm upload track.mp3 "Song Title" --album "Album Name"
+
+# upload with tags (can use -t multiple times)
+plyrfm upload track.mp3 "Song Title" -t electronic -t ambient
+
+# upload with album and tags
+plyrfm upload track.mp3 "Song Title" --album "Album Name" -t ai -t podcast
 ```
 
 ## supported formats
 mp3, wav, m4a
+
+## tags
+tags help users filter and discover tracks. common tags:
+- genre tags: electronic, ambient, hip-hop, etc.
+- content tags: ai (for AI-generated content), podcast, remix
 
 ## common issues
 - "artist_profile_required" -> user needs to create artist profile at plyr.fm/portal

--- a/packages/plyrfm/src/plyrfm/cli.py
+++ b/packages/plyrfm/src/plyrfm/cli.py
@@ -98,7 +98,9 @@ def cmd_my_tracks(limit: int = 20) -> None:
     console.print(table)
 
 
-def cmd_upload(file: str, title: str, album: str | None = None) -> None:
+def cmd_upload(
+    file: str, title: str, album: str | None = None, tags: set[str] | None = None
+) -> None:
     """upload a track (requires auth)."""
     client = _get_client(require_auth=True)
     path = Path(file)
@@ -108,7 +110,7 @@ def cmd_upload(file: str, title: str, album: str | None = None) -> None:
 
     with console.status("uploading..."):
         try:
-            result = client.upload(path, title, album=album)
+            result = client.upload(path, title, album=album, tags=tags)
         except FileNotFoundError:
             _error(f"file not found: {file}")
         except ValueError as e:
@@ -201,7 +203,7 @@ USAGE = """\
 
 [bold]authenticated commands:[/]
     my-tracks [--limit N]         list your tracks
-    upload <file> <title> [--album NAME]
+    upload <file> <title> [--album NAME] [-t TAG ...]
                                   upload a track
     download <id> [--output FILE] download a track
     delete <id> [--yes]           delete a track
@@ -215,6 +217,8 @@ USAGE = """\
     plyrfm list                                  # no auth needed
     plyrfm my-tracks                             # requires auth
     plyrfm upload track.mp3 "My Song"            # requires auth
+    plyrfm upload track.mp3 "My Song" -t ai      # with tag
+    plyrfm upload track.mp3 "My Song" -t ai -t podcast  # multiple tags
     plyrfm download 42 -o song.mp3               # requires auth
 """
 
@@ -247,15 +251,24 @@ def main() -> None:
 
     elif cmd == "upload":
         if len(args) < 3:
-            _error("usage: plyr upload <file> <title> [--album NAME]")
+            _error("usage: plyrfm upload <file> <title> [--album NAME] [-t TAG ...]")
         file = args[1]
         title = args[2]
         album = None
+        tags: set[str] = set()
         if "--album" in args:
             idx = args.index("--album")
             if idx + 1 < len(args):
                 album = args[idx + 1]
-        cmd_upload(file, title, album)
+        # collect all -t/--tag values
+        i = 0
+        while i < len(args):
+            if args[i] in ("-t", "--tag") and i + 1 < len(args):
+                tags.add(args[i + 1])
+                i += 2
+            else:
+                i += 1
+        cmd_upload(file, title, album, tags if tags else None)
 
     elif cmd == "download":
         if len(args) < 2:

--- a/packages/plyrfm/src/plyrfm/client.py
+++ b/packages/plyrfm/src/plyrfm/client.py
@@ -149,6 +149,7 @@ class PlyrClient(_BaseClient):
         title: str,
         *,
         album: str | None = None,
+        tags: set[str] | None = None,
         timeout: float = 300.0,
     ) -> UploadResult:
         """upload a track. requires auth + artist profile."""
@@ -159,9 +160,11 @@ class PlyrClient(_BaseClient):
 
         with open(file, "rb") as f:
             files = {"file": (file.name, f)}
-            data: dict[str, str] = {"title": title}
+            data: dict[str, str | list[str]] = {"title": title}
             if album:
                 data["album"] = album
+            if tags:
+                data["tags"] = list(tags)
 
             response = self._client.post(
                 self._url("/tracks/"),
@@ -374,6 +377,7 @@ class AsyncPlyrClient(_BaseClient):
         title: str,
         *,
         album: str | None = None,
+        tags: set[str] | None = None,
         timeout: float = 300.0,
     ) -> UploadResult:
         """upload a track. requires auth + artist profile."""
@@ -384,9 +388,11 @@ class AsyncPlyrClient(_BaseClient):
 
         with open(file, "rb") as f:
             files = {"file": (file.name, f)}
-            data: dict[str, str] = {"title": title}
+            data: dict[str, str | list[str]] = {"title": title}
             if album:
                 data["album"] = album
+            if tags:
+                data["tags"] = list(tags)
 
             response = await self._client.post(
                 self._url("/tracks/"),


### PR DESCRIPTION
## Summary
- adds `tags: set[str] | None` parameter to `upload()` in both `PlyrClient` and `AsyncPlyrClient`
- adds `-t/--tag` CLI option (can be used multiple times for multiple tags)
- updates MCP `upload_guide` prompt with tag examples

## Usage

### CLI
```bash
plyrfm upload track.mp3 "My Song" -t ai
plyrfm upload track.mp3 "My Song" -t ai -t podcast
plyrfm upload track.mp3 "My Song" --album "2024" -t ai -t podcast
```

### SDK
```python
client.upload("track.mp3", "My Song", tags={"ai", "podcast"})
```

closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)