### PR TITLE
fix: add missing unlisted field to Track model

### DIFF
--- a/packages/plyrfm/src/plyrfm/_internal/types.py
+++ b/packages/plyrfm/src/plyrfm/_internal/types.py
@@ -125,6 +125,7 @@ class Track(BaseModel):
     audio_url: str | None = Field(default=None, alias="r2_url")
     tags: list[str] = Field(default_factory=list)
     created_at: datetime | None = None
+    unlisted: bool = False
     atproto_uri: str | None = Field(default=None, alias="atproto_record_uri")
     atproto_cid: str | None = Field(default=None, alias="atproto_record_cid")
 


### PR DESCRIPTION
## Summary

- The backend API returns an `unlisted` field on track responses, but the SDK's `Track` Pydantic model didn't include it — so it was silently dropped during deserialization.
- This caused a debugging mismatch where MCP tool output showed a track as not unlisted when it actually was.
- Adds `unlisted: bool = False` to the `Track` class, positioned after `created_at` and before `atproto_uri`.

## Test plan

- [ ] Verify `Track.model_validate({"id": 1, "title": "t", "file_id": "f", "unlisted": True}).unlisted` returns `True`
- [ ] Verify existing track deserialization still works (field defaults to `False`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)