### PR TITLE
feat(upload): support unlisted tracks in SDK + CLI + MCP guide

### DIFF
--- a/packages/plyrfm-mcp/skills/cli/SKILL.md
+++ b/packages/plyrfm-mcp/skills/cli/SKILL.md
@@ -29,6 +29,9 @@ plyrfm upload track.mp3 "Song Title" --album "Album Name"
 
 # with tags (can use -t multiple times)
 plyrfm upload track.mp3 "Song Title" -t electronic -t ambient
+
+# as unlisted (excluded from discovery feeds, accessible by direct URL)
+plyrfm upload track.mp3 "Song Title" --unlisted
 ```
 
 supported formats: mp3, wav, m4a

--- a/packages/plyrfm-mcp/src/plyrfm_mcp/server.py
+++ b/packages/plyrfm-mcp/src/plyrfm_mcp/server.py
@@ -48,6 +48,9 @@ plyrfm tracks upload track.mp3 "Song Title" --album "Album Name"
 
 # upload with tags (can use -t multiple times)
 plyrfm tracks upload track.mp3 "Song Title" -t electronic -t ambient
+
+# upload as unlisted (excluded from discovery feeds, accessible by direct URL)
+plyrfm tracks upload track.mp3 "Song Title" --unlisted
 ```
 
 ## supported formats

--- a/packages/plyrfm/src/plyrfm/cli.py
+++ b/packages/plyrfm/src/plyrfm/cli.py
@@ -133,6 +133,14 @@ def tracks_upload(
         list[str] | None,
         cyclopts.Parameter("--tag", alias="-t", help="tag (repeatable)"),
     ] = None,
+    unlisted: Annotated[
+        bool,
+        cyclopts.Parameter(
+            "--unlisted",
+            help="exclude from public discovery feeds (latest, top, for-you); accessible by direct URL",
+            negative=(),
+        ),
+    ] = False,
 ) -> None:
     """upload a track."""
     client = _get_client(require_auth=True)
@@ -143,7 +151,9 @@ def tracks_upload(
     tags = set(tag) if tag else None
     with console.status("uploading..."):
         try:
-            result = client.tracks.upload(path, title, album=album, tags=tags)
+            result = client.tracks.upload(
+                path, title, album=album, tags=tags, unlisted=unlisted
+            )
         except ValueError as e:
             _error(str(e))
         except httpx.HTTPStatusError as e:

--- a/packages/plyrfm/src/plyrfm/cli.py
+++ b/packages/plyrfm/src/plyrfm/cli.py
@@ -133,6 +133,16 @@ def tracks_upload(
         list[str] | None,
         cyclopts.Parameter("--tag", alias="-t", help="tag (repeatable)"),
     ] = None,
+    description: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            "--description", help="track description (liner notes, show notes, etc.)"
+        ),
+    ] = None,
+    image: Annotated[
+        str | None,
+        cyclopts.Parameter("--image", help="path to cover art image (jpg/png/webp)"),
+    ] = None,
     unlisted: Annotated[
         bool,
         cyclopts.Parameter(
@@ -148,11 +158,23 @@ def tracks_upload(
     if not path.exists():
         _error(f"file not found: {file}")
 
+    image_path: Path | None = None
+    if image is not None:
+        image_path = Path(image)
+        if not image_path.exists():
+            _error(f"image not found: {image}")
+
     tags = set(tag) if tag else None
     with console.status("uploading..."):
         try:
             result = client.tracks.upload(
-                path, title, album=album, tags=tags, unlisted=unlisted
+                path,
+                title,
+                album=album,
+                tags=tags,
+                description=description,
+                image=image_path,
+                unlisted=unlisted,
             )
         except ValueError as e:
             _error(str(e))

--- a/packages/plyrfm/src/plyrfm/client.py
+++ b/packages/plyrfm/src/plyrfm/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 from importlib.metadata import version
 from pathlib import Path
@@ -175,6 +176,8 @@ class TracksNamespace(_SyncNamespace):
         *,
         album: str | None = None,
         tags: set[str] | None = None,
+        description: str | None = None,
+        image: Path | str | None = None,
         unlisted: bool = False,
         timeout: float = 300.0,
     ) -> UploadResult:
@@ -182,19 +185,34 @@ class TracksNamespace(_SyncNamespace):
 
         when `unlisted=True`, the track is excluded from public discovery
         feeds (latest, top, for-you) but remains accessible by direct URL.
+        when `image` is provided, the file becomes the track's cover art.
         """
         file = Path(file)
         if not file.exists():
             msg = f"file not found: {file}"
             raise FileNotFoundError(msg)
 
-        with open(file, "rb") as f:
-            files = {"file": (file.name, f)}
+        image_path: Path | None = None
+        if image is not None:
+            image_path = Path(image)
+            if not image_path.exists():
+                msg = f"image not found: {image_path}"
+                raise FileNotFoundError(msg)
+
+        with contextlib.ExitStack() as stack:
+            f = stack.enter_context(open(file, "rb"))
+            files: dict[str, tuple[str, object]] = {"file": (file.name, f)}
+            if image_path is not None:
+                img = stack.enter_context(open(image_path, "rb"))
+                files["image"] = (image_path.name, img)
+
             data: dict[str, str] = {"title": title}
             if album:
                 data["album"] = album
             if tags:
                 data["tags"] = json.dumps(list(tags))
+            if description:
+                data["description"] = description
             if unlisted:
                 data["unlisted"] = "true"
 
@@ -669,6 +687,8 @@ class AsyncTracksNamespace(_AsyncNamespace):
         *,
         album: str | None = None,
         tags: set[str] | None = None,
+        description: str | None = None,
+        image: Path | str | None = None,
         unlisted: bool = False,
         timeout: float = 300.0,
     ) -> UploadResult:
@@ -676,19 +696,34 @@ class AsyncTracksNamespace(_AsyncNamespace):
 
         when `unlisted=True`, the track is excluded from public discovery
         feeds (latest, top, for-you) but remains accessible by direct URL.
+        when `image` is provided, the file becomes the track's cover art.
         """
         file = Path(file)
         if not file.exists():
             msg = f"file not found: {file}"
             raise FileNotFoundError(msg)
 
-        with open(file, "rb") as f:
-            files = {"file": (file.name, f)}
+        image_path: Path | None = None
+        if image is not None:
+            image_path = Path(image)
+            if not image_path.exists():
+                msg = f"image not found: {image_path}"
+                raise FileNotFoundError(msg)
+
+        with contextlib.ExitStack() as stack:
+            f = stack.enter_context(open(file, "rb"))
+            files: dict[str, tuple[str, object]] = {"file": (file.name, f)}
+            if image_path is not None:
+                img = stack.enter_context(open(image_path, "rb"))
+                files["image"] = (image_path.name, img)
+
             data: dict[str, str] = {"title": title}
             if album:
                 data["album"] = album
             if tags:
                 data["tags"] = json.dumps(list(tags))
+            if description:
+                data["description"] = description
             if unlisted:
                 data["unlisted"] = "true"
 

--- a/packages/plyrfm/src/plyrfm/client.py
+++ b/packages/plyrfm/src/plyrfm/client.py
@@ -175,9 +175,14 @@ class TracksNamespace(_SyncNamespace):
         *,
         album: str | None = None,
         tags: set[str] | None = None,
+        unlisted: bool = False,
         timeout: float = 300.0,
     ) -> UploadResult:
-        """upload a track. requires auth + artist profile."""
+        """upload a track. requires auth + artist profile.
+
+        when `unlisted=True`, the track is excluded from public discovery
+        feeds (latest, top, for-you) but remains accessible by direct URL.
+        """
         file = Path(file)
         if not file.exists():
             msg = f"file not found: {file}"
@@ -190,6 +195,8 @@ class TracksNamespace(_SyncNamespace):
                 data["album"] = album
             if tags:
                 data["tags"] = json.dumps(list(tags))
+            if unlisted:
+                data["unlisted"] = "true"
 
             response = self._api._client.post(
                 self._api._url("/tracks/"),
@@ -662,8 +669,14 @@ class AsyncTracksNamespace(_AsyncNamespace):
         *,
         album: str | None = None,
         tags: set[str] | None = None,
+        unlisted: bool = False,
         timeout: float = 300.0,
     ) -> UploadResult:
+        """upload a track. requires auth + artist profile.
+
+        when `unlisted=True`, the track is excluded from public discovery
+        feeds (latest, top, for-you) but remains accessible by direct URL.
+        """
         file = Path(file)
         if not file.exists():
             msg = f"file not found: {file}"
@@ -676,6 +689,8 @@ class AsyncTracksNamespace(_AsyncNamespace):
                 data["album"] = album
             if tags:
                 data["tags"] = json.dumps(list(tags))
+            if unlisted:
+                data["unlisted"] = "true"
 
             response = await self._api._client.post(
                 self._api._url("/tracks/"),


### PR DESCRIPTION
## Summary
The backend's \`upload_track\` endpoint already accepts an \`unlisted\` form field that excludes a track from public discovery feeds (latest, top, for-you) while keeping it accessible by direct URL. The SDK and CLI didn't expose it.

This PR plumbs it through:
- \`PlyrClient.tracks.upload(..., unlisted=False)\` (sync)
- \`AsyncPlyrClient.tracks.upload(..., unlisted=False)\` (async — \`test_client_parity.py\` enforces sig alignment)
- \`plyrfm tracks upload --unlisted\` CLI flag
- MCP \`upload_guide\` prompt + CLI skill markdown updated so LLM clients surface the option

## Why
Want to smoke-test the new prod worker process group (zzstoatzz/plyr.fm#1359) by uploading a couple of albums under real load, but without polluting public discovery feeds during testing.

## Test plan
- [x] \`uv run pytest tests/test_client_parity.py\` — sig parity preserved
- [x] \`uv run ruff check\` clean
- [x] CLI help confirms \`--unlisted\` flag is recognized
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)