### PR TITLE
feat: support unlisted on tracks upload + update

### DIFF
--- a/packages/plyrfm/src/plyrfm/_internal/types.py
+++ b/packages/plyrfm/src/plyrfm/_internal/types.py
@@ -46,6 +46,7 @@ class TrackPatch(BaseModel):
     features: str | None = None
     tags: list[str] | None = None
     image: Path | str | None = None
+    unlisted: bool | None = None
 
     model_config = {"extra": "forbid"}
 

--- a/packages/plyrfm/src/plyrfm/cli.py
+++ b/packages/plyrfm/src/plyrfm/cli.py
@@ -133,6 +133,12 @@ def tracks_upload(
         list[str] | None,
         cyclopts.Parameter("--tag", alias="-t", help="tag (repeatable)"),
     ] = None,
+    unlisted: Annotated[
+        bool,
+        cyclopts.Parameter(
+            "--unlisted", help="exclude track from public discovery feeds"
+        ),
+    ] = False,
 ) -> None:
     """upload a track."""
     client = _get_client(require_auth=True)
@@ -143,7 +149,9 @@ def tracks_upload(
     tags = set(tag) if tag else None
     with console.status("uploading..."):
         try:
-            result = client.tracks.upload(path, title, album=album, tags=tags)
+            result = client.tracks.upload(
+                path, title, album=album, tags=tags, unlisted=unlisted
+            )
         except ValueError as e:
             _error(str(e))
         except httpx.HTTPStatusError as e:
@@ -161,12 +169,20 @@ def tracks_update(
     tags: Annotated[
         str | None, cyclopts.Parameter("--tags", help="comma-separated tags")
     ] = None,
+    unlisted: Annotated[
+        bool | None,
+        cyclopts.Parameter(
+            "--unlisted",
+            help="hide from public discovery (--unlisted to set, --no-unlisted to clear)",
+            negative="--no-unlisted",
+        ),
+    ] = None,
 ) -> None:
     """update track metadata."""
     client = _get_client(require_auth=True)
     track_ref = _parse_track_ref(ref)
     tag_list = [t.strip() for t in tags.split(",")] if tags else None
-    patch = TrackPatch(title=title, album=album, tags=tag_list)
+    patch = TrackPatch(title=title, album=album, tags=tag_list, unlisted=unlisted)
 
     try:
         track = client.tracks.update(track_ref, patch)

--- a/packages/plyrfm/src/plyrfm/client.py
+++ b/packages/plyrfm/src/plyrfm/client.py
@@ -175,6 +175,7 @@ class TracksNamespace(_SyncNamespace):
         *,
         album: str | None = None,
         tags: set[str] | None = None,
+        unlisted: bool = False,
         timeout: float = 300.0,
     ) -> UploadResult:
         """upload a track. requires auth + artist profile."""
@@ -190,6 +191,8 @@ class TracksNamespace(_SyncNamespace):
                 data["album"] = album
             if tags:
                 data["tags"] = json.dumps(list(tags))
+            if unlisted:
+                data["unlisted"] = "true"
 
             response = self._api._client.post(
                 self._api._url("/tracks/"),
@@ -301,6 +304,8 @@ class TracksNamespace(_SyncNamespace):
             data["features"] = patch.features
         if patch.tags is not None:
             data["tags"] = json.dumps(patch.tags)
+        if patch.unlisted is not None:
+            data["unlisted"] = "true" if patch.unlisted else "false"
 
         if patch.image is not None:
             image_path = Path(patch.image)
@@ -662,6 +667,7 @@ class AsyncTracksNamespace(_AsyncNamespace):
         *,
         album: str | None = None,
         tags: set[str] | None = None,
+        unlisted: bool = False,
         timeout: float = 300.0,
     ) -> UploadResult:
         file = Path(file)
@@ -676,6 +682,8 @@ class AsyncTracksNamespace(_AsyncNamespace):
                 data["album"] = album
             if tags:
                 data["tags"] = json.dumps(list(tags))
+            if unlisted:
+                data["unlisted"] = "true"
 
             response = await self._api._client.post(
                 self._api._url("/tracks/"),
@@ -787,6 +795,8 @@ class AsyncTracksNamespace(_AsyncNamespace):
             data["features"] = patch.features
         if patch.tags is not None:
             data["tags"] = json.dumps(patch.tags)
+        if patch.unlisted is not None:
+            data["unlisted"] = "true" if patch.unlisted else "false"
 
         if patch.image is not None:
             image_path = Path(patch.image)


### PR DESCRIPTION
## Summary
- backend already accepts `unlisted` on `POST /tracks/` and `PATCH /tracks/{id}`; the SDK was the only thing that didn't pass it through
- adds `unlisted: bool = False` to `tracks.upload` (sync + async)
- adds `unlisted: bool | None = None` to `TrackPatch` so `tracks.update` can flip it either direction (None = leave alone)
- CLI gets `--unlisted` on `upload` and `--unlisted` / `--no-unlisted` on `update`

## Test plan
- [x] existing parity + unit tests pass (`uv run pytest`)
- [x] live smoke test on prod track 973: `plyrfm tracks update 973 --no-unlisted` → server reports `unlisted=false`; `--unlisted` flips it back to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)