### PR TITLE
feat(plyrfm): support track description on upload + update

### DIFF
--- a/packages/plyrfm/src/plyrfm/_internal/types.py
+++ b/packages/plyrfm/src/plyrfm/_internal/types.py
@@ -47,6 +47,8 @@ class TrackPatch(BaseModel):
     tags: list[str] | None = None
     image: Path | str | None = None
     unlisted: bool | None = None
+    # liner notes / show notes. "" clears the existing description.
+    description: str | None = None
 
     model_config = {"extra": "forbid"}
 
@@ -115,6 +117,7 @@ class Track(BaseModel):
 
     id: int
     title: str
+    description: str | None = None  # liner notes / show notes
     file_id: str
     file_type: str = "mp3"
     artist: str = ""  # display name or handle

--- a/packages/plyrfm/src/plyrfm/cli.py
+++ b/packages/plyrfm/src/plyrfm/cli.py
@@ -139,6 +139,12 @@ def tracks_upload(
             "--unlisted", help="exclude track from public discovery feeds"
         ),
     ] = False,
+    description: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            "--description", help="track description (liner notes, show notes)"
+        ),
+    ] = None,
 ) -> None:
     """upload a track."""
     client = _get_client(require_auth=True)
@@ -150,7 +156,12 @@ def tracks_upload(
     with console.status("uploading..."):
         try:
             result = client.tracks.upload(
-                path, title, album=album, tags=tags, unlisted=unlisted
+                path,
+                title,
+                album=album,
+                tags=tags,
+                unlisted=unlisted,
+                description=description,
             )
         except ValueError as e:
             _error(str(e))
@@ -177,12 +188,25 @@ def tracks_update(
             negative="--no-unlisted",
         ),
     ] = None,
+    description: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            "--description",
+            help="track description (liner notes, show notes); pass '' to clear",
+        ),
+    ] = None,
 ) -> None:
     """update track metadata."""
     client = _get_client(require_auth=True)
     track_ref = _parse_track_ref(ref)
     tag_list = [t.strip() for t in tags.split(",")] if tags else None
-    patch = TrackPatch(title=title, album=album, tags=tag_list, unlisted=unlisted)
+    patch = TrackPatch(
+        title=title,
+        album=album,
+        tags=tag_list,
+        unlisted=unlisted,
+        description=description,
+    )
 
     try:
         track = client.tracks.update(track_ref, patch)

--- a/packages/plyrfm/src/plyrfm/client.py
+++ b/packages/plyrfm/src/plyrfm/client.py
@@ -176,6 +176,7 @@ class TracksNamespace(_SyncNamespace):
         album: str | None = None,
         tags: set[str] | None = None,
         unlisted: bool = False,
+        description: str | None = None,
         timeout: float = 300.0,
     ) -> UploadResult:
         """upload a track. requires auth + artist profile."""
@@ -193,6 +194,8 @@ class TracksNamespace(_SyncNamespace):
                 data["tags"] = json.dumps(list(tags))
             if unlisted:
                 data["unlisted"] = "true"
+            if description is not None:
+                data["description"] = description
 
             response = self._api._client.post(
                 self._api._url("/tracks/"),
@@ -306,6 +309,8 @@ class TracksNamespace(_SyncNamespace):
             data["tags"] = json.dumps(patch.tags)
         if patch.unlisted is not None:
             data["unlisted"] = "true" if patch.unlisted else "false"
+        if patch.description is not None:
+            data["description"] = patch.description
 
         if patch.image is not None:
             image_path = Path(patch.image)
@@ -668,6 +673,7 @@ class AsyncTracksNamespace(_AsyncNamespace):
         album: str | None = None,
         tags: set[str] | None = None,
         unlisted: bool = False,
+        description: str | None = None,
         timeout: float = 300.0,
     ) -> UploadResult:
         file = Path(file)
@@ -684,6 +690,8 @@ class AsyncTracksNamespace(_AsyncNamespace):
                 data["tags"] = json.dumps(list(tags))
             if unlisted:
                 data["unlisted"] = "true"
+            if description is not None:
+                data["description"] = description
 
             response = await self._api._client.post(
                 self._api._url("/tracks/"),
@@ -797,6 +805,8 @@ class AsyncTracksNamespace(_AsyncNamespace):
             data["tags"] = json.dumps(patch.tags)
         if patch.unlisted is not None:
             data["unlisted"] = "true" if patch.unlisted else "false"
+        if patch.description is not None:
+            data["description"] = patch.description
 
         if patch.image is not None:
             image_path = Path(patch.image)


### PR DESCRIPTION
Exposes the track `description` field through the SDK and CLI. The backend has accepted a `description` form field on both `POST /tracks/` and `PATCH /tracks/{id}` for a while (empty string clears it), but the python client never plumbed it through.

Motivation: the plyr.fm status-maintenance GitHub Action generates a podcast transcript, renders it to audio, and uploads the result as a track — but the transcript was thrown away. With this, that workflow can attach the transcript as the track's description.

<details>
<summary>changes</summary>

- **SDK**
  - `tracks.upload(..., description=...)` — sync + async
  - `TrackPatch.description` plumbed through `tracks.update` — sync + async
  - `Track.description` added to the read model so it round-trips (backend's `TrackResponse` already returns it)
- **CLI**
  - `--description` on `tracks upload`
  - `--description` on `tracks update` (pass `''` to clear, matching backend's empty-string-removes semantics)

</details>

intentional non-behaviors:
- on `update`, `None`/omitted leaves the description unchanged; only `''` clears it — mirrors the backend
- `upload` only sends the field when provided (no behavior change for existing callers)

tests: existing parity + suite pass (19); CLI `--help` shows both flags.